### PR TITLE
ci: add linting to CI and fix CODEOWNERS location

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @netanelavr

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,2 +1,0 @@
-# Currently require approval from
-* @netanelavr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,5 @@ jobs:
           node-version: '20.x'
       - run: npm ci
       - run: npm run build
+      - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## Summary
- Add linting step to CI workflow to catch formatting/lint errors before merge
- Fix CODEOWNERS location so GitHub actually enforces code review requirements

## Changes
- `.github/workflows/ci.yml` - Add `npm run lint` step before tests
- `.github/CODEOWNERS` - Moved from `.github/workflows/CODEOWNERS` (invalid location)

## Why
- CODEOWNERS was in `.github/workflows/` which GitHub ignores
- CI was not running lint, allowing code with lint errors to merge

## Test plan
- [x] CI workflow runs lint step
- [x] CODEOWNERS is in valid GitHub location

Made with [Cursor](https://cursor.com)