### PR TITLE
ci: fix Node.js version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Fix Node.js version from 24.x to 20.x (current LTS).

## Changes
- `.github/workflows/release.yml` - Change node-version from 24.x to 20.x

## Note
OIDC trusted publishing is already configured via `id-token: write` permission - no NPM_TOKEN secret needed.

## Test plan
- [x] Workflow syntax is valid
- [x] Node 20.x is current LTS