### PR TITLE
docs: improve README and fix CONTRIBUTING typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@
    ```bash
    npm install
    npm run test
-   npm run lint: fix
+   npm run lint:fix
    ```
 
 4. Commit your changes using semantic commits

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Effortlessly report metrics from anywhere in your codebase without complex setup
 [Overview](#overview) •
 [Quick Start](#quick-start) •
 [API Reference](#api-reference) •
+[Testing](#testing) •
 [Contributing](#contributing) •
 [License](#license)
 
@@ -234,6 +235,113 @@ test: message     # Adding or correcting tests
 ```
 
 Any other prefix will cause the commit to be ignored by semantic-release and won't appear anywhere in release notes.
+
+---
+
+## Testing
+
+### Unit Tests
+
+Run the test suite:
+
+```bash
+npm test
+```
+
+### Mocking ReporterService in Tests
+
+Since `ReporterService` uses static methods, you can mock it in your tests using Jest:
+
+```typescript
+// jest/setupFile.ts (optional - for global mocking)
+jest.mock('nestjs-metrics-reporter', () => ({
+  ReporterService: {
+    counter: jest.fn(),
+    gauge: jest.fn(),
+    histogram: jest.fn(),
+    summary: jest.fn(),
+    pushMetrics: jest.fn().mockResolvedValue(undefined),
+  },
+  ReporterModule: {
+    forRoot: jest.fn().mockReturnValue({
+      module: class MockReporterModule {},
+    }),
+    forRootAsync: jest.fn().mockReturnValue({
+      module: class MockReporterModule {},
+    }),
+  },
+}));
+```
+
+### Testing Services That Use ReporterService
+
+```typescript
+import { ReporterService } from 'nestjs-metrics-reporter';
+import { UserService } from './user.service';
+
+jest.mock('nestjs-metrics-reporter');
+
+describe('UserService', () => {
+  let service: UserService;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new UserService();
+  });
+
+  it('should increment counter when creating user', async () => {
+    await service.createUser({ email: 'test@example.com' });
+
+    expect(ReporterService.counter).toHaveBeenCalledWith(
+      'users_created_total',
+      expect.objectContaining({ source: 'api' })
+    );
+  });
+
+  it('should update gauge for active users', async () => {
+    await service.updateActiveUsers(42);
+
+    expect(ReporterService.gauge).toHaveBeenCalledWith(
+      'active_users',
+      42,
+      expect.any(Object)
+    );
+  });
+});
+```
+
+### Testing with NestJS Testing Module
+
+For integration tests, you can use the NestJS testing utilities:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReporterModule, ReporterService } from 'nestjs-metrics-reporter';
+
+describe('Integration Test', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        ReporterModule.forRoot({
+          defaultMetricsEnabled: false,
+          defaultLabels: { env: 'test' },
+        }),
+      ],
+    }).compile();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('should report metrics', () => {
+    ReporterService.counter('test_metric', { action: 'test' });
+    // Metrics are recorded - verify via /metrics endpoint if needed
+  });
+});
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "CONTRIBUTING.md",
+    "LICENSE"
   ],
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
## Summary
- Add Testing section to README with practical mocking examples
- Fix typo in CONTRIBUTING.md
- Include documentation files in npm package

## Changes
- `README.md` - Add Testing section with:
  - Unit test mocking examples
  - Service testing patterns
  - NestJS TestingModule integration
- `CONTRIBUTING.md` - Fix `lint: fix` → `lint:fix` typo
- `package.json` - Add README, CONTRIBUTING, LICENSE to `files` array

## Test plan
- [x] README renders correctly on GitHub
- [x] Code examples are syntactically correct

Made with [Cursor](https://cursor.com)